### PR TITLE
うまくいかなかったテストケース作成用ブランチ

### DIFF
--- a/backend/database/factories/NewsFactory.php
+++ b/backend/database/factories/NewsFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\News;
+use Faker\Generator as Faker;
+
+$factory->define(News::class, function (Faker $faker) {
+    return [
+        
+        'title' => $faker->title,
+        'messages' => $faker->text,
+        'file_name' => $faker->randomDigit,
+        
+    ];
+});

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <server name="APP_ENV" value="testing"/>
-        <server name="BCRYPT_ROUNDS" value="4"/>
-        <server name="CACHE_DRIVER" value="array"/>
-        <server name="DB_CONNECTION" value="mysql"/>
-        <server name="DB_DATABASE" value="laravel_local"/>
-        <server name="MAIL_DRIVER" value="array"/>
-        <server name="QUEUE_CONNECTION" value="sync"/>
-        <server name="SESSION_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+    <server name="BCRYPT_ROUNDS" value="4"/>
+    <server name="CACHE_DRIVER" value="array"/>
+    <server name="DB_CONNECTION" value="mysql"/>
+    <server name="DB_DATABASE" value="laravel_local"/>
+    <server name="MAIL_DRIVER" value="array"/>
+    <server name="QUEUE_CONNECTION" value="sync"/>
+    <server name="SESSION_DRIVER" value="array"/>
+  </php>
 </phpunit>

--- a/backend/phpunit.xml.bak
+++ b/backend/phpunit.xml.bak
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./app</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="mysql"/>
+        <server name="DB_DATABASE" value="laravel_local"/>
+        <server name="MAIL_DRIVER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/backend/tests/Feature/AdminNewsControllerTest.php
+++ b/backend/tests/Feature/AdminNewsControllerTest.php
@@ -17,7 +17,7 @@ class AdminNewsControllerTest extends TestCase
         parent::setUp();
         // テストユーザ作成
         $this->user = factory(User::class)->create();
-        $this->another_user = factory(User::class)->create();
+
         $notice = factory(News::class)->create();
         // logger($notice);
         logger('test');
@@ -29,10 +29,15 @@ class AdminNewsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testExample()
+    public function test_ログイン済みユーザーが管理画面「お知らせ一覧」に入れる()
     {
-        // $response = $this->get('/');
+        // ログインしていないので302が返される
+        $response = $this->get(route('admin-news.index'));
+        $response->assertStatus(302);
 
-        // $response->assertStatus(200);
+        // ログインユーザー　通常動作
+        $response = $this->actingAs($this->user)->get(route('admin-news.index'));
+        $response->assertStatus(200);
+        $response->assertSee('<h4>お知らせ</h4>');
     }
 }

--- a/backend/tests/Feature/AdminNewsControllerTest.php
+++ b/backend/tests/Feature/AdminNewsControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+use App\News;
+use Faker\Generator as Faker;
+
+class AdminNewsControllerTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/backend/tests/Feature/AdminNewsControllerTest.php
+++ b/backend/tests/Feature/AdminNewsControllerTest.php
@@ -9,8 +9,21 @@ use App\User;
 use App\News;
 use Faker\Generator as Faker;
 
+
 class AdminNewsControllerTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        // テストユーザ作成
+        $this->user = factory(User::class)->create();
+        $this->another_user = factory(User::class)->create();
+        $notice = factory(News::class)->create();
+        // logger($notice);
+        logger('test');
+    }
+
+
     /**
      * A basic feature test example.
      *
@@ -18,8 +31,8 @@ class AdminNewsControllerTest extends TestCase
      */
     public function testExample()
     {
-        $response = $this->get('/');
+        // $response = $this->get('/');
 
-        $response->assertStatus(200);
+        // $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
ファイルアップロード周りのテストがうまくいかなかった残骸のコードが残っているかと思っていたのですが、ごちゃごちゃやっているうちにその辺りを一旦削除した状態のものが残っていて、ほとんど参考にならなそうです。